### PR TITLE
Set locale to avoid point to comma mixup

### DIFF
--- a/shims/Peptide_identification_in_TSV_to_Peptide_identification_in_mzIdentML.sh
+++ b/shims/Peptide_identification_in_TSV_to_Peptide_identification_in_mzIdentML.sh
@@ -12,6 +12,9 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
+# Avoid inconsistencies in AWK output resulting from locale settings
+export LC_ALL=C
+
 # get the current date and time (of the conversion to mzIdentML)
 creationDate=`date -I'ns'|tr ',' '.'| awk 'sub("00\+.+","Z")'`
 


### PR DESCRIPTION
AWK uses a decimal comma for locales such as Dutch. This is fixed by setting the locale to "C"